### PR TITLE
Add support for Orange Pi One

### DIFF
--- a/layers/meta-resin-allwinner/recipes-core/images/resin-image.inc
+++ b/layers/meta-resin-allwinner/recipes-core/images/resin-image.inc
@@ -16,6 +16,24 @@ IMAGE_CMD_resinos-img_append_orangepi-plus2 () {
     dd if=${DEPLOY_DIR_IMAGE}/u-boot-sunxi-with-spl.bin of=${RESIN_RAW_IMG} conv=notrunc seek=8 bs=1024
 }
 
+#
+# Orange Pi One
+#
+
+IMAGE_FSTYPES_append_orange-pi-one = " resinos-img"
+
+# Customize resinos-img
+RESIN_IMAGE_BOOTLOADER_orange-pi-one = "u-boot"
+RESIN_BOOT_PARTITION_FILES_orange-pi-one = " \
+    ${KERNEL_IMAGETYPE}${KERNEL_INITRAMFS}-${MACHINE}.bin:/${KERNEL_IMAGETYPE} \
+    uImage-sun8i-h3-orangepi-one.dtb:/dtb/sun8i-h3-orangepi-one.dtb \
+    u-boot-sunxi-with-spl.bin: \
+"
+IMAGE_CMD_resinos-img_append_orange-pi-one () {
+    # Orange Pi One needs uboot written at a specific location
+    dd if=${DEPLOY_DIR_IMAGE}/u-boot-sunxi-with-spl.bin of=${RESIN_RAW_IMG} conv=notrunc seek=8 bs=1024
+}
+
 
 #
 # bananapi-M1+

--- a/orange-pi-one.coffee
+++ b/orange-pi-one.coffee
@@ -1,0 +1,35 @@
+
+deviceTypesCommon = require '@resin.io/device-types/common'
+{ networkOptions, commonImg, instructions } = deviceTypesCommon
+
+module.exports =
+	version: 1
+	slug: 'orange-pi-one'
+	name: 'Orange Pi One'
+	arch: 'armv7hf'
+	state: 'experimental'
+
+	instructions: commonImg.instructions
+	gettingStartedLink:
+		windows: 'https://docs.resin.io/orange-pi-one/nodejs/getting-started/#adding-your-first-device'
+		osx: 'https://docs.resin.io/orange-pi-one/nodejs/getting-started/#adding-your-first-device'
+		linux: 'https://docs.resin.io/orange-pi-one/nodejs/getting-started/#adding-your-first-device'
+	supportsBlink: true
+
+	options: [ networkOptions.group ]
+
+	yocto:
+		machine: 'orange-pi-one'
+		image: 'resin-image'
+		fstype: 'resinos-img'
+		version: 'yocto-sumo'
+		deployArtifact: 'resin-image-orange-pi-one.resinos-img'
+		compressed: true
+
+	configuration:
+		config:
+			partition:
+				primary: 1
+			path: '/config.json'
+
+	initialization: commonImg.initialization


### PR DESCRIPTION
Hi,

I have this board and just managed to build the latest version for resinOS (or should I say BalinaOS ;) -- `Resin OS 2.19.0+rev1`) for it. It is now running like a charm and the device is correctly sending information to the balenaCloud.

I am new to Yocto, please tell me if I forget something.

Thank you.