### PR TITLE
nanopi-air-bt: Load BT firmware according to chip revision

### DIFF
--- a/layers/meta-resin-allwinner/recipes-bsp/nanopi-air-bt/nanopi-air-bt/nanopi-air-bt-start
+++ b/layers/meta-resin-allwinner/recipes-bsp/nanopi-air-bt/nanopi-air-bt/nanopi-air-bt-start
@@ -13,5 +13,12 @@ echo "Resetting BT chip"
 echo 0 > /sys/class/gpio/gpio205/value
 echo 1 > /sys/class/gpio/gpio205/value
 
-/usr/bin/brcm_patchram_plus -d --patchram /lib/firmware/brcm/bcm43438a1.hcd --no2bytes --tosleep 5000 $1 > /tmp/brcm_log 2>&1
+CHIP_REV=`dmesg | grep brcmfm | grep "chip 0x00a9a6" | awk '{print $11}'`
+BT_FIRMWARE="bcm43438a0.hcd" # AP6212 chip
+
+if [ "$CHIP_REV" = "0x000001" ]; then
+    BT_FIRMWARE="bcm43438a1.hcd" # AP6212A chip
+fi
+
+/usr/bin/brcm_patchram_plus -d --patchram /lib/firmware/brcm/$BT_FIRMWARE --no2bytes --tosleep 5000 $1 > /tmp/brcm_log 2>&1
 hciattach -n $1 bcm43xx 115200 flow


### PR DESCRIPTION
NanoPi Neo Air commes with tho different BT/WiFi chip versions:
AP6212 or AP6212A.
This commit loads a different BT firmware based on the chip
revisions of this board.

Changelog-entry: nanopi-air-bt: Load BT firmware according to chip revision
Signed-off-by: Sebastian Panceac <sebastian@balena.io>