### PR TITLE
orange-pi-zero: Add overlay files to RESIN_BOOT_PARTITION_FILES and K…

### DIFF
--- a/layers/meta-balena-allwinner/recipes-core/images/resin-image.inc
+++ b/layers/meta-balena-allwinner/recipes-core/images/resin-image.inc
@@ -104,6 +104,26 @@ RESIN_IMAGE_BOOTLOADER_orange-pi-zero = "u-boot"
 RESIN_BOOT_PARTITION_FILES_orange-pi-zero = " \
     ${KERNEL_IMAGETYPE}${KERNEL_INITRAMFS}-${MACHINE}.bin:/${KERNEL_IMAGETYPE} \
     sun8i-h2-plus-orangepi-zero.dtb:/dtb/sun8i-h2-plus-orangepi-zero.dtb \
+    sun8i-h3-fixup.scr:/dtb/overlay/sun8i-h3-fixup.scr \
+    sun8i-h3-analog-codec.dtbo:/dtb/overlay/sun8i-h3-analog-codec.dtbo \
+    sun8i-h3-cir.dtbo:/dtb/overlay/sun8i-h3-cir.dtbo \
+    sun8i-h3-i2c0.dtbo:/dtb/overlay/sun8i-h3-i2c0.dtbo \
+    sun8i-h3-i2c1.dtbo:/dtb/overlay/sun8i-h3-i2c1.dtbo \
+    sun8i-h3-i2c2.dtbo:/dtb/overlay/sun8i-h3-i2c2.dtbo \
+    sun8i-h3-pps-gpio.dtbo:/dtb/overlay/sun8i-h3-pps-gpio.dtbo \
+    sun8i-h3-pwm.dtbo:/dtb/overlay/sun8i-h3-pwm.dtbo \
+    sun8i-h3-spdif-out.dtbo:/dtb/overlay/sun8i-h3-spdif-out.dtbo \
+    sun8i-h3-spi-add-cs1.dtbo:/dtb/overlay/sun8i-h3-spi-add-cs1.dtbo \
+    sun8i-h3-spi-jedec-nor.dtbo:/dtb/overlay/sun8i-h3-spi-jedec-nor.dtbo \
+    sun8i-h3-spi-spidev.dtbo:/dtb/overlay/sun8i-h3-spi-spidev.dtbo \
+    sun8i-h3-uart1.dtbo:/dtb/overlay/sun8i-h3-uart1.dtbo \
+    sun8i-h3-uart2.dtbo:/dtb/overlay/sun8i-h3-uart2.dtbo \
+    sun8i-h3-uart3.dtbo:/dtb/overlay/sun8i-h3-uart3.dtbo \
+    sun8i-h3-usbhost0.dtbo:/dtb/overlay/sun8i-h3-usbhost0.dtbo \
+    sun8i-h3-usbhost2.dtbo:/dtb/overlay/sun8i-h3-usbhost1.dtbo \
+    sun8i-h3-usbhost3.dtbo:/dtb/overlay/sun8i-h3-usbhost2.dtbo \
+    sun8i-h3-w1-gpio.dtbo:/dtb/overlay/sun8i-h3-w1-gpio.dtbo \
+    boot.scr:/boot.scr \
     u-boot-sunxi-with-spl.bin: \
 "
 IMAGE_CMD_resinos-img_append_orange-pi-zero () {

--- a/layers/meta-balena-allwinner/recipes-kernel/linux/linux-mainline_%.bbappend
+++ b/layers/meta-balena-allwinner/recipes-kernel/linux/linux-mainline_%.bbappend
@@ -1,4 +1,5 @@
 inherit kernel-resin
+inherit kernel-devicetree
 
 PACKAGES =+ "${PN}-fixup-scr"
 
@@ -69,3 +70,25 @@ RESIN_CONFIGS[8189fs] ?= " \
 FILES_${PN}-fixup-scr = " \
     /boot/sun8i-h3-fixup.scr \
 "
+KERNEL_DEVICETREE_orange-pi-zero_append = " \
+    sun8i-h2-plus-orangepi-zero.dtb \
+    overlay/sun8i-h3-analog-codec.dtbo \
+    overlay/sun8i-h3-cir.dtbo \
+    overlay/sun8i-h3-fixup.scr \
+    overlay/sun8i-h3-i2c0.dtbo \
+    overlay/sun8i-h3-i2c1.dtbo \
+    overlay/sun8i-h3-i2c2.dtbo \
+    overlay/sun8i-h3-pps-gpio.dtbo \
+    overlay/sun8i-h3-pwm.dtbo \
+    overlay/sun8i-h3-spdif-out.dtbo \
+    overlay/sun8i-h3-spi-add-cs1.dtbo \
+    overlay/sun8i-h3-spi-jedec-nor.dtbo \
+    overlay/sun8i-h3-spi-spidev.dtbo \
+    overlay/sun8i-h3-uart1.dtbo \
+    overlay/sun8i-h3-uart2.dtbo \
+    overlay/sun8i-h3-uart3.dtbo \
+    overlay/sun8i-h3-usbhost0.dtbo \
+    overlay/sun8i-h3-usbhost2.dtbo \
+    overlay/sun8i-h3-usbhost3.dtbo \
+    overlay/sun8i-h3-w1-gpio.dtbo \
+    "


### PR DESCRIPTION
…ERNEL_DEVICETREE

Update the RESIN_BOOT_PARTITION_FILES of resin-image.inc and KERNEL_DEVICETREE
of linux-mainline_%.bbappend for the orange-pi-zero machine.

Changelog-entry: Add overlays for orange-pi-zero
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>