### PR TITLE
linux-mainline_%.bbappend: Add kernel config for overlayfs

### DIFF
--- a/layers/meta-balena-allwinner/recipes-bsp/u-boot/u-boot_2019.04.bbappend
+++ b/layers/meta-balena-allwinner/recipes-bsp/u-boot/u-boot_2019.04.bbappend
@@ -3,17 +3,15 @@ inherit resin-u-boot pythonnative
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-#remove the resin-specific-env-integration-kconfig.patch patch from meta-resin
-#and the 0001-nanopi_neo_air_defconfig-Enable-eMMC-support.patch patch from
-#meta-sunxi because these fail to apply
-SRC_URI_remove = "file://0001-nanopi_neo_air_defconfig-Enable-eMMC-support.patch \
-                  file://resin-specific-env-integration-kconfig.patch"
+# remove the resin-specific-env-integration-kconfig.patch patch from meta-resin
+# because it fails to apply
+SRC_URI_remove = "file://resin-specific-env-integration-kconfig.patch"
 
-#Add updated patches for 0001-nanopi_neo_air_defconfig-Enable-eMMC-support.patch
-#and for 0001-nanopi_neo_air_defconfig-Enable-eMMC-support.patch
-SRC_URI += "file://0001-Add-Resin-specific-boot-command.patch \
-            file://resin-specific-env-integration-kconfig.patch \
-           "
+# Add re-worked patch which was previously removed
+SRC_URI_append = " \
+	file://0001-Add-Resin-specific-boot-command.patch \
+	file://resin-specific-env-integration-kconfig_reworked.patch \
+	"
 
 do_deploy_append() {
     install -m 0644 ${WORKDIR}/armbianEnv.txt ${DEPLOYDIR}/armbianEnv.txt

--- a/layers/meta-balena-allwinner/recipes-kernel/linux/linux-mainline_%.bbappend
+++ b/layers/meta-balena-allwinner/recipes-kernel/linux/linux-mainline_%.bbappend
@@ -67,6 +67,16 @@ RESIN_CONFIGS[8189fs] ?= " \
     CONFIG_RTL8189FS=m \
 "
 
+RESIN_CONFIGS_append = " \
+    configfs \
+"
+
+RESIN_CONFIGS[configfs] = " \
+    CONFIG_OF_CONFIGFS=y \
+    CONFIG_OF_OVERLAY=y \
+    CONFIG_CONFIGFS_FS=m \
+"
+
 FILES_${PN}-fixup-scr = " \
     /boot/sun8i-h3-fixup.scr \
 "


### PR DESCRIPTION
The directory /sys/kernel/config/device-tree was not present
in the file system and overlays could not be applied.
This patch enables configfs

Changelog-entry: Add configs in the kernel to enable configfs
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>