### PR TITLE
resin-image.inc: Fix orange-pi-lite image for hostapp updates

### DIFF
--- a/layers/meta-balena-allwinner/recipes-core/images/resin-image.inc
+++ b/layers/meta-balena-allwinner/recipes-core/images/resin-image.inc
@@ -84,6 +84,7 @@ RESIN_BOOT_PARTITION_FILES_orange-pi-lite = " \
     sun8i-h3-usbhost3.dtbo:/dtb/overlay/sun8i-h3-usbhost2.dtbo \
     sun8i-h3-w1-gpio.dtbo:/dtb/overlay/sun8i-h3-w1-gpio.dtbo \
     boot.scr:/boot.scr \
+    u-boot-sunxi-with-spl.bin: \
     armbianEnv.txt:/ \
     "
 


### PR DESCRIPTION
Include u-boot-sunxi-with-spl.bin in orange-pi-lite partition files to prevent hostapp updates from failing

Changelog-Entry: Fix orange-pi-lite image for hostapp updates
Signed-off-by: Michel Wohlert <michel.wohlert@googlemail.com>