### PR TITLE
linux-mainline_%.bbappend: Add NFLX-2019-001 patches

### DIFF
--- a/layers/meta-balena-allwinner/recipes-kernel/linux/linux-mainline/0003-NFLX-2019-001-SACK-Panic-for-lteq-4.14.patch
+++ b/layers/meta-balena-allwinner/recipes-kernel/linux/linux-mainline/0003-NFLX-2019-001-SACK-Panic-for-lteq-4.14.patch
@@ -1,0 +1,65 @@
+From 53494ae1afc7c9c4b527c158c7d836a5673fc5cf Mon Sep 17 00:00:00 2001
+From: Vicentiu Galanopulo <vicentiu@balena.io>
+Date: Tue, 7 Jan 2020 15:46:31 +0100
+Subject: [PATCH] From cd4ffa93f16efea290bb70537f98f518e1927e63 Mon Sep 17
+ 00:00:00 2001 From: Joao Martins <joao.m.martins@oracle.com> Date: Mon, 10
+ Jun 2019 23:12:39 +0100 Subject: [PATCH 5/5] tcp: fix fack_count accounting
+ on tcp_shift_skb_data()
+
+v4.15 or since commit 737ff314563 ("tcp: use sequence distance to
+detect reordering") had switched from the packet-based FACK tracking
+to sequence-based.
+
+v4.14 and older still have the old logic and hence on
+tcp_skb_shift_data() needs to retain its original logic and have
+@fack_count in sync. In other words, we keep the increment of pcount with
+tcp_skb_pcount(skb) to later used that to update fack_count. To make it
+more explicit we track the new skb that gets incremented to pcount in
+@next_pcount, and we get to avoid the constant invocation of
+tcp_skb_pcount(skb) all together.
+
+Fixes: a5f1faa40101 ("tcp: limit payload size of sacked skbs")
+Reported-by: Alexey Kodanev <alexey.kodanev@oracle.com>
+Reviewed-by: Jack Vogel <jack.vogel@oracle.com>
+Reviewed-by: John Haxby <john.haxby@oracle.com>
+Reviewed-by: Rao Shoaib rao.shoaib@oracle.com>
+Signed-off-by: Joao Martins <joao.m.martins@oracle.com>
+Signed-off-by: Konrad Rzeszutek Wilk <konrad.wilk@oracle.com>
+
+Upstream-Status: Inappropriate [not author]
+Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>
+---
+ net/ipv4/tcp_input.c | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/net/ipv4/tcp_input.c b/net/ipv4/tcp_input.c
+index 14a6a48..bac45dc 100644
+--- a/net/ipv4/tcp_input.c
++++ b/net/ipv4/tcp_input.c
+@@ -1407,6 +1407,7 @@ static struct sk_buff *tcp_shift_skb_data(struct sock *sk, struct sk_buff *skb,
+ 	struct tcp_sock *tp = tcp_sk(sk);
+ 	struct sk_buff *prev;
+ 	int mss;
++	int next_pcount;
+ 	int pcount = 0;
+ 	int len;
+ 	int in_sack;
+@@ -1519,10 +1520,12 @@ static struct sk_buff *tcp_shift_skb_data(struct sock *sk, struct sk_buff *skb,
+ 		goto out;
+ 
+ 	len = skb->len;
+-	pcount = tcp_skb_pcount(skb);
+-	if (tcp_skb_shift(prev, skb, pcount, len))
+-		tcp_shifted_skb(sk, prev, skb, state, pcount,
++	next_pcount = tcp_skb_pcount(skb);
++	if (tcp_skb_shift(prev, skb, next_pcount, len)) {
++		pcount += next_pcount;
++		tcp_shifted_skb(sk, prev, skb, state, next_pcount,
+ 				len, mss, 0);
++	}
+ 
+ out:
+ 	return prev;
+-- 
+2.7.4
+

--- a/layers/meta-balena-allwinner/recipes-kernel/linux/linux-mainline/0004-NFLX-2019-001-SACK-Slowness.patch
+++ b/layers/meta-balena-allwinner/recipes-kernel/linux/linux-mainline/0004-NFLX-2019-001-SACK-Slowness.patch
@@ -1,0 +1,54 @@
+From f51319da0f2c66df5c5f8837336e9f8dbe417358 Mon Sep 17 00:00:00 2001
+From: Vicentiu Galanopulo <vicentiu@balena.io>
+Date: Tue, 7 Jan 2020 15:48:39 +0100
+Subject: [PATCH] Date: Sat,  8 Jun 2019 10:38:06 -0700 Subject: [PATCH net
+ 2/4] tcp: tcp_fragment() should apply sane memory limits From: Eric Dumazet
+ <edumazet@google.com>
+
+Jonathan Looney reported that a malicious peer can force a sender
+to fragment its retransmit queue into tiny skbs, inflating memory
+usage and/or overflow 32bit counters.
+
+TCP allows an application to queue up to sk_sndbuf bytes,
+so we need to give some allowance for non malicious splitting
+of retransmit queue.
+
+A new SNMP counter is added to monitor how many times TCP
+did not allow to split an skb if the allowance was exceeded.
+
+Note that this counter might increase in the case applications
+use SO_SNDBUF socket option to lower sk_sndbuf.
+
+Signed-off-by: Eric Dumazet <edumazet@google.com>
+Reported-by: Jonathan Looney <jtl@netflix.com>
+Acked-by: Neal Cardwell <ncardwell@google.com>
+Acked-by: Yuchung Cheng <ycheng@google.com>
+Reviewed-by: Tyler Hicks <tyhicks@canonical.com>
+Cc: Bruce Curtis <brucec@netflix.com>
+Cc: Jonathan Lemon <jonathan.lemon@gmail.com>
+
+Upstream-Status: Inappropriate [not author]
+Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>
+---
+ net/ipv4/tcp_output.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/net/ipv4/tcp_output.c b/net/ipv4/tcp_output.c
+index 2697e43..23329ea 100644
+--- a/net/ipv4/tcp_output.c
++++ b/net/ipv4/tcp_output.c
+@@ -1300,6 +1300,11 @@ int tcp_fragment(struct sock *sk, enum tcp_queue tcp_queue,
+ 	if (nsize < 0)
+ 		nsize = 0;
+ 
++	if (unlikely((sk->sk_wmem_queued >> 1) > sk->sk_sndbuf)) {
++		NET_INC_STATS(sock_net(sk), LINUX_MIB_TCPWQUEUETOOBIG);
++		return -ENOMEM;
++	}
++
+ 	/* tcp_sendmsg() can overshoot sk_wmem_queued by one full size skb.
+ 	 * We need some allowance to not penalize applications setting small
+ 	 * SO_SNDBUF values.
+-- 
+2.7.4
+

--- a/layers/meta-balena-allwinner/recipes-kernel/linux/linux-mainline_%.bbappend
+++ b/layers/meta-balena-allwinner/recipes-kernel/linux/linux-mainline_%.bbappend
@@ -3,6 +3,11 @@ inherit kernel-devicetree
 
 PACKAGES =+ "${PN}-fixup-scr"
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/linux-mainline:"
+
+SRC_URI_append = " file://0003-NFLX-2019-001-SACK-Panic-for-lteq-4.14.patch \
+	file://0004-NFLX-2019-001-SACK-Slowness.patch"
+
 do_kernel_configme[depends] += "virtual/${TARGET_PREFIX}binutils:do_populate_sysroot"
 do_kernel_configme[depends] += "virtual/${TARGET_PREFIX}gcc:do_populate_sysroot"
 do_kernel_configme[depends] += "bc-native:do_populate_sysroot bison-native:do_populate_sysroot"


### PR DESCRIPTION
Add remaining patches for multiple TCP-based remote denial
of service vulnerabilities identified by Netflix.
Patch source:
https://github.com/Netflix/security-bulletins/blob/master/advisories/third-party/2019-001.md

Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>