### PR TITLE
coffee: Set state to 'released'

### DIFF
--- a/bananapi-m1-plus.coffee
+++ b/bananapi-m1-plus.coffee
@@ -7,7 +7,7 @@ module.exports =
 	slug: 'bananapi-m1-plus'
 	name: 'BananaPi-M1+'
 	arch: 'armv7hf'
-	state: 'experimental'
+	state: 'released'
 
 	instructions: commonImg.instructions
 	gettingStartedLink:

--- a/nanopi-neo-air.coffee
+++ b/nanopi-neo-air.coffee
@@ -13,7 +13,7 @@ module.exports =
 	slug: 'nanopi-neo-air'
 	name: 'Nanopi Neo Air'
 	arch: 'armv7hf'
-	state: 'experimental'
+	state: 'released'
 
 	stateInstructions:
 		postProvisioning: postProvisioningInstructions

--- a/orange-pi-lite.coffee
+++ b/orange-pi-lite.coffee
@@ -7,7 +7,7 @@ module.exports =
 	slug: 'orange-pi-lite'
 	name: 'Orange Pi Lite'
 	arch: 'armv7hf'
-	state: 'experimental'
+	state: 'released'
 
 	instructions: commonImg.instructions
 	gettingStartedLink:

--- a/orangepi-plus2.coffee
+++ b/orangepi-plus2.coffee
@@ -13,7 +13,7 @@ module.exports =
 	slug: 'orangepi-plus2'
 	name: 'Orange Pi Plus2'
 	arch: 'armv7hf'
-	state: 'experimental'
+	state: 'released'
 
 	stateInstructions:
 		postProvisioning: postProvisioningInstructions


### PR DESCRIPTION
Change the state field to 'released'
instead of 'experimental' for all the
non-community boards

Changelog-entry: Change the state to 'released' in the coffee file
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>