### PR TITLE
linux-mainline: Add missing kernel module bluetooth dependency

### DIFF
--- a/layers/meta-balena-allwinner/recipes-kernel/linux/linux-mainline_%.bbappend
+++ b/layers/meta-balena-allwinner/recipes-kernel/linux/linux-mainline_%.bbappend
@@ -89,6 +89,9 @@ RESIN_CONFIGS[configfs] = " \
 "
 
 RESIN_CONFIGS_append_nanopi-neo-air = " hciuart"
+RESIN_CONFIGS_DEPS[hciuart] = " \
+    CONFIG_BT=m \
+"
 RESIN_CONFIGS[hciuart] = " \
     CONFIG_BT_HCIUART=m \
     CONFIG_BT_HCIUART_H4=y \


### PR DESCRIPTION
Changelog-entry: Add missing kernel module bluetooth dependency for NanoPi Neo Air
Signed-off-by: Florin Sarbu <florin@balena.io>