### PR TITLE
linux-mainline_%.bbappend: Enable CONFIG_MODULE_UNLOAD

### DIFF
--- a/layers/meta-balena-allwinner/recipes-kernel/linux/linux-mainline_%.bbappend
+++ b/layers/meta-balena-allwinner/recipes-kernel/linux/linux-mainline_%.bbappend
@@ -104,6 +104,11 @@ RESIN_CONFIGS[hciuart] = " \
     CONFIG_BT_HCIUART_H4=y \
 "
 
+RESIN_CONFIGS_append = " module_unload"
+RESIN_CONFIGS[module_unload] = " \
+    CONFIG_MODULE_UNLOAD=y \
+"
+
 FILES_${PN}-fixup-scr = " \
     /boot/sun8i-h3-fixup.scr \
 "


### PR DESCRIPTION
Add this kernel configuration option to
be able to unload any modules

Changelog-entry: Enable kernel config CONFIG_MODULE_UNLOAD
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>