### PR TITLE
conf: disable user-ns for orange-pi-one

### DIFF
--- a/layers/meta-balena-allwinner/conf/layer.conf
+++ b/layers/meta-balena-allwinner/conf/layer.conf
@@ -9,3 +9,6 @@ BBFILE_PRIORITY_balena-allwinner = "1337"
 
 LAYERSERIES_COMPAT_balena-allwinner = "warrior"
 LAYERSERIES_COMPAT_meta-sunxi = "warrior"
+
+# Leave user namespacing disabled at runtime to match upstream
+DISTRO_FEATURES_append_orange-pi-one = " disable-user-ns"


### PR DESCRIPTION
Disable user namespacing for Orange Pi One to match upstream behavior.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>