### PR TITLE
conf: disable user-ns for several allwinner DTs

### DIFF
--- a/layers/meta-balena-allwinner/conf/layer.conf
+++ b/layers/meta-balena-allwinner/conf/layer.conf
@@ -9,3 +9,10 @@ BBFILE_PRIORITY_balena-allwinner = "1337"
 
 LAYERSERIES_COMPAT_balena-allwinner = "warrior"
 LAYERSERIES_COMPAT_meta-sunxi = "warrior"
+
+# Leave user namespacing disabled at runtime to match upstream
+DISTRO_FEATURES_append_orange-pi-one = " disable-user-ns"
+DISTRO_FEATURES_append_nanopi-neo-air = " disable-user-ns"
+DISTRO_FEATURES_append_orange-pi-zero = " disable-user-ns"
+DISTRO_FEATURES_append_orangepi-plus2 = " disable-user-ns"
+DISTRO_FEATURES_append_bananapi-m1-plus = " disable-user-ns"


### PR DESCRIPTION
Disable user namespacing for Orange Pi One, NanoPi Neo Air, Orange Pi
Zero, Orange Pi Plus 2, and Banana Pi M1+ to match upstream behavior.

Related to: https://github.com/balena-os/meta-balena/issues/2319

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>