### PR TITLE
linux-firmware: Fix wifi for BananaPi M1+

### DIFF
--- a/layers/meta-balena-allwinner/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/layers/meta-balena-allwinner/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -11,6 +11,7 @@ SRC_URI_append = " \
     file://brcmfmac43430-sdio.txt \
     file://bcm43438a0.hcd \
     file://bcm43438a1.hcd \
+    file://brcmfmac43362-sdio.txt \
     "
 
 do_install_append() {
@@ -20,6 +21,7 @@ do_install_append() {
     cp ${WORKDIR}/brcmfmac43430a0-sdio.bin ${D}/lib/firmware/brcm/brcmfmac43430a0-sdio.bin
     cp ${WORKDIR}/brcmfmac43430a0-sdio.txt ${D}/lib/firmware/brcm/brcmfmac43430a0-sdio.txt
     cp ${WORKDIR}/config.txt ${D}/lib/firmware/brcm/config.txt
+    cp ${WORKDIR}/brcmfmac43362-sdio.txt ${D}/lib/firmware/brcm/brcmfmac43362-sdio.txt
 }
 
 do_install_append_nanopi-neo-air() {


### PR DESCRIPTION
Wifi did not work on the BananaPi M1+ before this
commit, so we have to install the specific bcm43362-sdio file for this device type.

This firmware configuration file is specific to the M1+ and comes from https://github.com/armbian/firmware/blob/master/ap6210/nvram_ap6210.txt and has the checksum fb1ab0d5148e3f58ce94598665828713.

Changelog-entry: linux-firmware: Fix wifi for BananaPi M1+
Signed-off-by: Alexandru Costache <alexandru@balena.io>