### PR TITLE
workflows: build and deploy: allow multi-digit revisions

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -3,7 +3,7 @@ name: 'Deploy on release tag'
 on:
   push:
     tags:
-      - v[0-9]+.[0-9]+.[0-9]+\+?r?e?v?[0-9]?
+      - v[0-9]+.[0-9]+.[0-9]+\+?r?e?v?*
       - v20[0-9][0-9].[0-1]?[1470].[0-9]+
 
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
According to github action syntax [1], there is no special character
to denote a match on zero or more of the preceding character, so
replace `[0-9]?` which only matches zero or one of the preceding
characters with a `*`.

[1] https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

Changelog-entry: trigger deploy builds on multi-digit revisions too
Signed-off-by: Alex Gonzalez <alexg@balena.io>
